### PR TITLE
Change Slack URL to renamed Slack workspace

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -15,7 +15,7 @@
                 <a id="status" href="/timecard">
                     <img src="{% if config.DEBUG %}https://thewhitehat.club{% endif %}/status.svg">
                 </a>
-                <a id="slack" href="https://join.slack.com/t/whitehatcalpoly/signup" rel="nofollow noopener" target="_blank">
+                <a id="slack" href="https://join.slack.com/t/cpsecurity/signup" rel="nofollow noopener" target="_blank">
                     <img src="/slack-logo.png" height="36px" alt="Join our Slack workspace!">
                     <p>Slack</p>
                 </a>


### PR DESCRIPTION
Just renamed the slack to be `cpsecurity.slack.com`, so this change should be all good to change the footer link